### PR TITLE
Add Support for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "coverage": "jest --coverage",
     "release": "cd dist && npm publish",
     "build": "./scripts/build",
-    "preversion": "yarn lint && yarn build && yarn coverage"
+    "build:windows": "ts-node ./scripts/build.ts",
+    "preversion": "yarn lint && yarn build && yarn coverage",
+    "preversion:windows": "yarn lint && yarn build:windows && yarn coverage"
   },
   "dependencies": {
     "bluebird": "^3.5.0",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,50 @@
+import exec = require('execa');
+import { chmod, copy, exists, lstatSync, mkdir, readdir, remove } from 'fs-extra';
+import path = require('path');
+
+new Promise<boolean>((resolve) => exists('./dist', resolve))
+  .then((exists) => { if (exists) { return remove('./dist'); } })
+  .then(() => { console.log('Creating dist'); return mkdir('dist'); })
+  .then(() => { console.log('Building typescript'); return exec('tsc') as PromiseLike<void>; })
+  .then(() => {
+    console.log('Copying files to ./dist');
+    return readdir('.')
+      .then((files) => {
+        return files
+          .filter((file) => lstatSync(file).isFile())
+          .reduce((chain, file) => chain.then(() => {
+            const dest = path.join('./dist', path.relative('./', file));
+            console.log(`\t${file} -> ${dest}`);
+            return copy(file, dest);
+          }), Promise.resolve());
+      });
+  })
+  .then(() => {
+    console.log('Cleaning up spurious files');
+    const filesToRemove = [
+      '__tests__',
+      '.gitignore',
+    ];
+    return filesToRemove.reduce((chain, file) => chain.then(() => {
+      const dest = path.join('./dist', file);
+      console.log(`\tRemoving ${dest}`);
+      return remove(dest);
+    }), Promise.resolve());
+  })
+  .then(() => {
+    const execBits = parseInt('111', 8);
+    console.log('Making ./dist/bin/* executable');
+    return readdir('./dist/bin').then((files) => {
+      return files
+        .map((name) => path.join('./dist/bin', name))
+        .filter((file) => lstatSync(file).isFile())
+        .reduce((chain, file) => chain.then(() => {
+          const stat = lstatSync(file);
+          console.log(`\tchmod +x ${file} :: `
+            // tslint:disable-next-line:no-bitwise
+            + `0${(stat.mode).toString(8)} -> 0${(stat.mode | execBits).toString(8)}`);
+          // tslint:disable-next-line:no-bitwise
+          return chmod(file, stat.mode | execBits);
+        }), Promise.resolve());
+    });
+  });

--- a/src/__tests__/actions.test.ts
+++ b/src/__tests__/actions.test.ts
@@ -16,6 +16,9 @@ describe('actions', () => {
     samplePackage = require('./testProject/sample.package.json');
 
     writeFileSync(actualPackagePath, JSON.stringify(samplePackage));
+
+    // Make sure the actual package.json is reloaded for each test by removing it from the require() cache
+    delete require.cache[require.resolve(actualPackagePath)];
   });
 
   it('resolved deps', () => {
@@ -26,7 +29,33 @@ describe('actions', () => {
     expect(resolved.keys.sort()).toEqual(['chalk', 'jest'].sort());
   });
 
-  it('installs types', async () => {
+  it('installs types w/ yarn', async () => {
+    await installTypes(resolved.keys, { selections: resolved.selections, pwd, packageManager: 'yarn' });
+
+    const actualPackage = require(actualPackagePath);
+
+    [
+      [actualPackage.dependencies, expectedPackage.dependencies],
+      [actualPackage.devDependencies, expectedPackage.devDependencies],
+    ].forEach(([actual, expected]) => {
+      expect(Object.keys(actual).sort()).toEqual(Object.keys(expected).sort());
+    });
+  });
+
+  it('installs types w/ npm', async () => {
+    await installTypes(resolved.keys, { selections: resolved.selections, pwd, packageManager: 'npm' });
+
+    const actualPackage = require(actualPackagePath);
+
+    [
+      [actualPackage.dependencies, expectedPackage.dependencies],
+      [actualPackage.devDependencies, expectedPackage.devDependencies],
+    ].forEach(([actual, expected]) => {
+      expect(Object.keys(actual).sort()).toEqual(Object.keys(expected).sort());
+    });
+  });
+
+  it('installs types w/ auto-discovery', async () => {
     await installTypes(resolved.keys, { selections: resolved.selections, pwd });
 
     const actualPackage = require(actualPackagePath);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
       "es2015"
     ]
   },
-  "exclude": [ "dist" ],
+  "exclude": [ "dist","src/__tests__/testProject/**/*" ],
   "include": [ "src/**/*" ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,11 +27,7 @@
   version "21.1.8"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-21.1.8.tgz#d497213725684f1e5a37900b17a47c9c018f1a97"
 
-"@types/node@*":
-  version "7.0.12"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.12.tgz#ae5f67a19c15f752148004db07cbbb372e69efc9"
-
-"@types/node@^8.0.53":
+"@types/node@*", "@types/node@^8.0.53":
   version "8.0.53"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.53.tgz#396b35af826fa66aad472c8cb7b8d5e277f4e6d8"
 
@@ -377,15 +373,7 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-istanbul@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.1.tgz#c12de0fc6fe42adfb16be56f1ad11e4a9782eca9"
-  dependencies:
-    find-up "^2.1.0"
-    istanbul-lib-instrument "^1.6.2"
-    test-exclude "^4.0.3"
-
-babel-plugin-istanbul@^4.1.4:
+babel-plugin-istanbul@^4.0.0, babel-plugin-istanbul@^4.1.4:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz#6760cdd977f411d3e175bb064f2bc327d99b2b6e"
   dependencies:
@@ -450,17 +438,7 @@ babel-runtime@^6.26.0, babel-runtime@^6.9.2:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-template@^6.16.0, babel-template@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-    babylon "^6.11.0"
-    lodash "^4.2.0"
-
-babel-template@^6.26.0:
+babel-template@^6.16.0, babel-template@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:
@@ -469,6 +447,16 @@ babel-template@^6.26.0:
     babel-types "^6.26.0"
     babylon "^6.18.0"
     lodash "^4.17.4"
+
+babel-template@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+    babylon "^6.11.0"
+    lodash "^4.2.0"
 
 babel-traverse@^6.18.0, babel-traverse@^6.24.1:
   version "6.24.1"
@@ -498,16 +486,7 @@ babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.18.0, babel-types@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
-  dependencies:
-    babel-runtime "^6.22.0"
-    esutils "^2.0.2"
-    lodash "^4.2.0"
-    to-fast-properties "^1.0.1"
-
-babel-types@^6.26.0:
+babel-types@^6.18.0, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -516,17 +495,22 @@ babel-types@^6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0:
+babel-types@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
+  dependencies:
+    babel-runtime "^6.22.0"
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^1.0.1"
+
+babylon@^6.11.0:
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
 
-babylon@^6.18.0:
+babylon@^6.15.0, babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
-
-balanced-match@^0.4.1:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -557,13 +541,6 @@ boom@2.x.x:
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
   dependencies:
     hoek "2.x.x"
-
-brace-expansion@^1.0.0:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
-  dependencies:
-    balanced-match "^0.4.1"
-    concat-map "0.0.1"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -724,13 +701,9 @@ content-type-parser@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.1.tgz#c3e56988c53c65127fb46d4032a3a900246fdc94"
 
-convert-source-map@^1.1.0:
+convert-source-map@^1.1.0, convert-source-map@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
-
-convert-source-map@^1.4.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
 core-js@^2.4.0:
   version "2.4.1"
@@ -1139,18 +1112,7 @@ glob2base@^0.0.12:
   dependencies:
     find-index "^0.1.1"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.2:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -1158,6 +1120,17 @@ glob@^7.1.2:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -1453,10 +1426,6 @@ istanbul-lib-coverage@^1.0.1, istanbul-lib-coverage@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
 
-istanbul-lib-coverage@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.2.tgz#87a0c015b6910651cb3b184814dfb339337e25e1"
-
 istanbul-lib-hook@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz#8538d970372cb3716d53e55523dd54b557a8d89b"
@@ -1473,18 +1442,6 @@ istanbul-lib-instrument@^1.4.2, istanbul-lib-instrument@^1.7.5, istanbul-lib-ins
     babel-types "^6.18.0"
     babylon "^6.18.0"
     istanbul-lib-coverage "^1.1.1"
-    semver "^5.3.0"
-
-istanbul-lib-instrument@^1.6.2:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.0.tgz#b8e0dc25709bb44e17336ab47b7bb5c97c23f659"
-  dependencies:
-    babel-generator "^6.18.0"
-    babel-template "^6.16.0"
-    babel-traverse "^6.18.0"
-    babel-types "^6.18.0"
-    babylon "^6.13.0"
-    istanbul-lib-coverage "^1.0.2"
     semver "^5.3.0"
 
 istanbul-lib-report@^1.1.2:
@@ -1953,17 +1910,11 @@ mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
-minimatch@^3.0.0, minimatch@^3.0.4:
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
     brace-expansion "^1.1.7"
-
-minimatch@^3.0.2, minimatch@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
-  dependencies:
-    brace-expansion "^1.0.0"
 
 minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
@@ -2424,13 +2375,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.7:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
-  dependencies:
-    path-parse "^1.0.5"
-
-resolve@^1.3.2:
+resolve@^1.1.7, resolve@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.2.tgz#1f0442c9e0cbb8136e87b9305f932f46c7f28235"
   dependencies:
@@ -2714,16 +2659,6 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
-test-exclude@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.0.3.tgz#86a13ce3effcc60e6c90403cf31a27a60ac6c4e7"
-  dependencies:
-    arrify "^1.0.1"
-    micromatch "^2.3.11"
-    object-assign "^4.1.0"
-    read-pkg-up "^1.0.1"
-    require-main-filename "^1.0.1"
-
 test-exclude@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.1.1.tgz#4d84964b0966b0087ecc334a2ce002d3d9341e26"
@@ -2812,11 +2747,7 @@ tsconfig@^6.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
-tslib@^1.0.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.6.0.tgz#cf36c93e02ae86a20fc131eae511162b869a6652"
-
-tslib@^1.7.1:
+tslib@^1.0.0, tslib@^1.7.1:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.0.tgz#dc604ebad64bcbf696d613da6c954aa0e7ea1eb6"
 
@@ -2891,11 +2822,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@*:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.2.tgz#606022508479b55ffa368b58fee963a03dfd7b0c"
-
-typescript@^2.6.1:
+typescript@*, typescript@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
 


### PR DESCRIPTION
This also fixes #1 by replacing the check for yarn.

This adds support for Windows-based dev machines.  To do this, there are two major changes:

- The build script was rewritten in javascript, so that I could actually run a build and test locally.
I'm nearly sure the replacement is semantically equivalent to the sh-based build script.  I compared the results with the current npm package's contents, to ensure only the files in the package are in the dist folder.  I am less certain about the effects of the `find` command on line 16, since I couldn't find any documentation on some of the expressions being used.

- The check for yarn was replaced with a more cross-platform way, `yarn --version`, which works on all platforms and also makes sure that yarn is actually executable.  Using `which yarn` was problematic in a couple ways:
  - Windows does not have the `which` Unix command by default
  - None of the `which` command polyfills actually respects Windows' `PATHEXT` environment variable for thier search, so you would actually have to use `which yarn.cmd` to find it.

I also modified the tests for installTypes() to test both yarn and npm, since I had a brief indication that npm was not actually working.