### PR TITLE
yarn is always chosen as a package manager

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -75,7 +75,7 @@ export async function installTypes (
   const installCommand = await (async () => {
     if (packageManager === 'pnpm') { return 'pnpm install'; }
 
-    packageManager = packageManager || await getYarnVersion() ? 'yarn' : 'npm';
+    packageManager = packageManager || (await getYarnVersion() ? 'yarn' : 'npm');
 
     if (packageManager === 'yarn') { return 'yarn add'; }
 


### PR DESCRIPTION
Steps to reproduce:
1. Remove yarn and leave only npm.
2. Run interactive command.
3. Choose npm as package manager.
4. All types are failed to install; after adding debug code you can see that it is because yarn is chosen to install.